### PR TITLE
Add progress bar renderer

### DIFF
--- a/acm/__init__.py
+++ b/acm/__init__.py
@@ -1,0 +1,5 @@
+"""Article Checklist Manager core package."""
+
+from .progress import TaskNode, progress_bar, render_tree
+
+__all__ = ["TaskNode", "progress_bar", "render_tree"]

--- a/acm/progress.py
+++ b/acm/progress.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+@dataclass
+class TaskNode:
+    """Represents a checklist item with an optional percentage and subtasks."""
+
+    name: str
+    percent: Optional[float] = None  # 0-100
+    children: List['TaskNode'] = field(default_factory=list)
+
+    def computed_percent(self) -> float:
+        """Return this node's progress percent, averaging children if needed."""
+        if self.percent is not None:
+            return float(self.percent)
+        if not self.children:
+            return 0.0
+        return sum(child.computed_percent() for child in self.children) / len(self.children)
+
+
+def progress_bar(percent: float, width: int = 20, filled: str = "█", empty: str = "░") -> str:
+    """Return a textual progress bar for the given percent."""
+    percent = max(0.0, min(100.0, percent))
+    filled_len = int(round(width * percent / 100))
+    return filled * filled_len + empty * (width - filled_len)
+
+
+def render_tree(node: TaskNode, indent: int = 0, bar_width: int = 20) -> str:
+    """Render the task tree with progress bars using indentation."""
+    pct = node.computed_percent()
+    bar = progress_bar(pct, bar_width)
+    lines = [f"{'  '*indent}{node.name}: [{bar}] {pct:6.2f}%"]
+    for child in node.children:
+        lines.append(render_tree(child, indent + 1, bar_width))
+    return "\n".join(lines)
+
+__all__ = ["TaskNode", "progress_bar", "render_tree"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,21 @@
+from acm.progress import TaskNode, progress_bar, render_tree
+
+def test_progress_bar_basic():
+    assert progress_bar(0, width=10) == "░" * 10
+    assert progress_bar(50, width=10) == "█" * 5 + "░" * 5
+    assert progress_bar(100, width=10) == "█" * 10
+
+
+def test_render_tree():
+    root = TaskNode("Root", children=[
+        TaskNode("Child1", percent=50),
+        TaskNode("Child2", percent=100)
+    ])
+    output = render_tree(root, bar_width=10)
+    expected_lines = [
+        "Root: [████████░░]  75.00%",
+        "  Child1: [█████░░░░░]  50.00%",
+        "  Child2: [██████████] 100.00%",
+    ]
+    assert output.splitlines() == expected_lines
+


### PR DESCRIPTION
## Summary
- implement a basic progress bar rendering module
- expose package API
- add tests for bar display and tree rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be3da91808321a0f8e4f1f4ed5323