### PR TITLE
Add pytest harness with coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.coverage
+.pytest_cache/

--- a/acm/__main__.py
+++ b/acm/__main__.py
@@ -1,0 +1,4 @@
+from .cli import app
+
+if __name__ == "__main__":
+    app()

--- a/acm/cli.py
+++ b/acm/cli.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import sys
+import yaml
+from pathlib import Path
+import typer
+
+from .schema import SchemaError, validate_schema
+from .progress import compute_progress
+
+
+app = typer.Typer(help="Article Checklist Manager prototype")
+
+
+@app.command()
+def validate(path: Path) -> None:
+    """Validate a YAML checklist file."""
+    if not path.exists():
+        typer.echo(f"File not found: {path}", err=True)
+        raise typer.Exit(1)
+    try:
+        data = yaml.safe_load(path.read_text())
+        validate_schema(data)
+    except (yaml.YAMLError, SchemaError) as exc:
+        typer.echo(f"Invalid checklist: {exc}", err=True)
+        raise typer.Exit(1)
+    typer.echo("Checklist valid")
+
+
+@app.command()
+def progress(path: Path) -> None:
+    """Compute progress for a YAML checklist file."""
+    if not path.exists():
+        typer.echo(f"File not found: {path}", err=True)
+        raise typer.Exit(1)
+    try:
+        data = yaml.safe_load(path.read_text())
+        validate_schema(data)
+    except (yaml.YAMLError, SchemaError) as exc:
+        typer.echo(f"Invalid checklist: {exc}", err=True)
+        raise typer.Exit(1)
+
+    for name, task in data.items():
+        pct = compute_progress(task)
+        typer.echo(f"{name}: {pct:.0f}%")

--- a/acm/progress.py
+++ b/acm/progress.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def compute_progress(task: Dict[str, Any]) -> float:
+    """Return progress percentage for a task tree."""
+    if "percent" in task and isinstance(task["percent"], (int, float)):
+        return float(task["percent"])
+
+    if "done" in task:
+        return 100.0 if task.get("done") else 0.0
+
+    subtasks = task.get("subtasks") or []
+    if not subtasks:
+        return 0.0
+
+    total = sum(compute_progress(t) for t in subtasks)
+    return total / len(subtasks)

--- a/acm/schema.py
+++ b/acm/schema.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class SchemaError(ValueError):
+    """Raised when a task does not conform to the expected schema."""
+
+
+def validate_task(task: Any) -> None:
+    """Recursively validate a task dict.
+
+    Expected keys:
+    - item: required string
+    - done: optional bool
+    - percent: optional int between 0 and 100
+    - subtasks: optional list of tasks
+    """
+    if not isinstance(task, dict):
+        raise SchemaError("task must be a dict")
+
+    if "item" not in task or not isinstance(task["item"], str):
+        raise SchemaError("task must have an 'item' string")
+
+    if "done" in task and not isinstance(task["done"], bool):
+        raise SchemaError("'done' must be a boolean if present")
+
+    if "percent" in task:
+        percent = task["percent"]
+        if not isinstance(percent, (int, float)):
+            raise SchemaError("'percent' must be a number")
+        if not 0 <= percent <= 100:
+            raise SchemaError("'percent' must be between 0 and 100")
+
+    if "subtasks" in task:
+        if not isinstance(task["subtasks"], list):
+            raise SchemaError("'subtasks' must be a list")
+        for sub in task["subtasks"]:
+            validate_task(sub)
+
+
+def validate_schema(data: Dict[str, Any]) -> None:
+    """Validate the root schema which is a mapping of section name to task."""
+    if not isinstance(data, dict):
+        raise SchemaError("root must be a mapping")
+    for key, val in data.items():
+        if not isinstance(key, str):
+            raise SchemaError("section names must be strings")
+        validate_task(val)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "article-checklist-manager"
+version = "0.0.0"
+authors = [{name="ACM Dev"}]
+requires-python = ">=3.8"
+dependencies = [
+    "typer>=0.7",
+    "PyYAML>=6.0"
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.4",
+    "pytest-cov>=4.0"
+]
+
+[tool.pytest.ini_options]
+addopts = "-vv --cov=acm"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,32 @@
+import tempfile
+from pathlib import Path
+
+import yaml
+from typer.testing import CliRunner
+
+from acm.cli import app
+
+runner = CliRunner()
+
+
+def test_validate_nonexistent_file():
+    result = runner.invoke(app, ["validate", "nope.yaml"])
+    assert result.exit_code != 0
+    assert "File not found" in result.stderr
+
+
+def test_progress_invalid_yaml(tmp_path):
+    path = tmp_path / "bad.yaml"
+    path.write_text("foo: [")
+    result = runner.invoke(app, ["progress", str(path)])
+    assert result.exit_code != 0
+    assert "Invalid checklist" in result.stderr
+
+
+def test_progress_valid(tmp_path):
+    data = {"Sec": {"item": "task", "done": True}}
+    path = tmp_path / "good.yaml"
+    path.write_text(yaml.dump(data))
+    result = runner.invoke(app, ["progress", str(path)])
+    assert result.exit_code == 0
+    assert "Sec: 100%" in result.stdout

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,22 @@
+from acm.progress import compute_progress
+
+
+def test_leaf_done():
+    t = {"item": "x", "done": True}
+    assert compute_progress(t) == 100.0
+
+
+def test_average_subtasks():
+    t = {
+        "item": "p",
+        "subtasks": [
+            {"item": "a", "percent": 50},
+            {"item": "b", "done": False},
+        ],
+    }
+    assert compute_progress(t) == 25.0
+
+
+def test_percent_override():
+    t = {"item": "p", "percent": 70, "subtasks": [{"item": "a", "done": False}]}
+    assert compute_progress(t) == 70.0

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,19 @@
+import pytest
+from acm import schema
+
+
+def test_valid_schema():
+    data = {"Section": {"item": "task", "done": True}}
+    schema.validate_schema(data)
+
+
+def test_missing_item():
+    bad = {"Section": {"done": True}}
+    with pytest.raises(schema.SchemaError):
+        schema.validate_schema(bad)
+
+
+def test_percent_out_of_range():
+    bad = {"Section": {"item": "task", "percent": 120}}
+    with pytest.raises(schema.SchemaError):
+        schema.validate_schema(bad)


### PR DESCRIPTION
## Summary
- add minimal package skeleton and CLI
- implement schema validation and progress calculation
- configure pytest with coverage
- add unit tests for schema, progress, and CLI edge cases

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be3ea09f08321b442602e933b49a8