### PR TITLE
Update install instructions and Colab

### DIFF
--- a/Colab_Tutorial.ipynb
+++ b/Colab_Tutorial.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Article Checklist Manager Tutorial\n",
-    "This short Colab guide shows how to install and run the `acm` command line tool."
+    "This Colab guide shows how to install and use the `acm` toolbox directly from GitHub."
    ]
   },
   {
@@ -14,8 +14,8 @@
    "id": "fcaca3ad",
    "metadata": {},
    "source": [
-    "## Install\n",
-    "Install the package from PyPI. If you are running this notebook from the project repository, you can also run `pip install -e .`."
+    "## Install from GitHub\n",
+    "Clone the repository and install it in editable mode."
    ]
   },
   {
@@ -25,7 +25,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install article-checklist-manager"
+    "!git clone https://github.com/<your-username>/Article_Checklist_Manager.git\n",
+    "%cd Article_Checklist_Manager\n",
+    "!pip install -e ."
    ]
   },
   {
@@ -103,6 +105,24 @@
    "outputs": [],
    "source": [
     "!acm status"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export checklist\n",
+    "You can export the progress report to Markdown for sharing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!acm export --format markdown > checklist.md\n",
+    "!head checklist.md"
    ]
   }
  ],

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 📝 Article Checklist Manager
 
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/<your-username>/Article_Checklist_Manager/blob/main/Colab_Tutorial.ipynb)
+
 An open-source tool that helps research teams track, from the top-level section down to the tiniest to-do, how close a manuscript is to being submission-ready.
 
 ⸻
@@ -47,10 +49,16 @@ An open-source tool that helps research teams track, from the top-level section 
 
 🔧 Quick Install (CLI Prototype)
 
-pip install article-checklist-manager   # coming soon on PyPI
+Clone the repository and install it locally until the PyPI release is available:
+
+```bash
+git clone https://github.com/<your-username>/Article_Checklist_Manager.git
+cd Article_Checklist_Manager
+pip install -e .
 acm init MyGreatPaper
 acm status
 acm check "Results/Fig 3/Statistical review" --percent 75
+```
 
 
 ⸻


### PR DESCRIPTION
## Summary
- add a Colab badge to the README
- replace pip instructions with GitHub clone instructions
- expand the Colab tutorial so it installs from GitHub and shows export steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c82f239388321a8d72f7e52a01ca6