### PR TITLE
Fix Colab link

### DIFF
--- a/Colab_Tutorial.ipynb
+++ b/Colab_Tutorial.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!git clone https://github.com/<your-username>/Article_Checklist_Manager.git\n",
+    "!git clone https://github.com/jobellet/Article_Checklist_Manager.git\n",
     "%cd Article_Checklist_Manager\n",
     "!pip install -e ."
    ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 📝 Article Checklist Manager
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/<your-username>/Article_Checklist_Manager/blob/main/Colab_Tutorial.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/jobellet/Article_Checklist_Manager/blob/main/Colab_Tutorial.ipynb)
 
 An open-source tool that helps research teams track, from the top-level section down to the tiniest to-do, how close a manuscript is to being submission-ready.
 
@@ -52,7 +52,7 @@ An open-source tool that helps research teams track, from the top-level section 
 Clone the repository and install it locally until the PyPI release is available:
 
 ```bash
-git clone https://github.com/<your-username>/Article_Checklist_Manager.git
+git clone https://github.com/jobellet/Article_Checklist_Manager.git
 cd Article_Checklist_Manager
 pip install -e .
 acm init MyGreatPaper


### PR DESCRIPTION
## Summary
- fix placeholder GitHub username in README and Colab tutorial

## Testing
- `pip install pyyaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c84742e6c8321a6e092aadc1bbe34