### PR TITLE
Add Colab helper and notebook improvements

### DIFF
--- a/Colab_Tutorial.ipynb
+++ b/Colab_Tutorial.ipynb
@@ -1,132 +1,146 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "5e37f385",
-   "metadata": {},
-   "source": [
-    "# Article Checklist Manager Tutorial\n",
-    "This Colab guide shows how to install and use the `acm` toolbox directly from GitHub."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fcaca3ad",
-   "metadata": {},
-   "source": [
-    "## Install from GitHub\n",
-    "Clone the repository and install it in editable mode."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "818e7808",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!git clone https://github.com/jobellet/Article_Checklist_Manager.git\n",
-    "%cd Article_Checklist_Manager\n",
-    "!pip install -e ."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9e865772",
-   "metadata": {},
-   "source": [
-    "## Initialize a project\n",
-    "Create a new checklist project directory."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7dd13402",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!acm init DemoPaper"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "92ea6b96",
-   "metadata": {},
-   "source": [
-    "## Check progress\n",
-    "Move into the project folder and show the initial status."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8a2c8312",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%cd DemoPaper\n",
-    "!acm status"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0fb7c0cd",
-   "metadata": {},
-   "source": [
-    "## Update tasks\n",
-    "Use `acm check` to mark items as complete or set percentages."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "131756bc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!acm check \"Introduction/Outline\" --done\n",
-    "!acm check \"Methods/Data collection\" --percent 50"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1b253eeb",
-   "metadata": {},
-   "source": [
-    "## View updated status"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c5a53360",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!acm status"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Export checklist\n",
-    "You can export the progress report to Markdown for sharing."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "!acm export --format markdown > checklist.md\n",
-    "!head checklist.md"
-   ]
-  }
- ],
- "metadata": {},
- "nbformat": 4,
- "nbformat_minor": 5
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "5e37f385",
+      "metadata": {},
+      "source": [
+        "# Article Checklist Manager Tutorial\n",
+        "This Colab guide shows how to install and use the `acm` toolbox directly from GitHub."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Quick setup\n",
+        "Run the following cell to clone the repo, install dependencies, and create a demo project. When executed on Google Colab, your Drive will be mounted automatically so progress persists."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from acm.colab import setup\n",
+        "project_path = setup(\"DemoPaper\", repo_url=\"https://github.com/jobellet/Article_Checklist_Manager.git\")\n",
+        "project_path"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "%cd $project_path"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "9e865772",
+      "metadata": {},
+      "source": [
+        "## Manual project initialisation (optional)\n",
+        "The `setup` helper already creates the `DemoPaper` folder. The following command shows how you would initialise a project manually."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "92ea6b96",
+      "metadata": {},
+      "source": [
+        "## Check project status\n",
+        "Display the progress after initial setup."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8a2c8312",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!acm status"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "0fb7c0cd",
+      "metadata": {},
+      "source": [
+        "## Update tasks\n",
+        "Use `acm check` to mark items as complete or set percentages."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "131756bc",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!acm check \"Introduction/Outline\" --done\n",
+        "!acm check \"Methods/Data collection\" --percent 50"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "1b253eeb",
+      "metadata": {},
+      "source": [
+        "## View updated status"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c5a53360",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!acm status"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Inspect saved checklist\n",
+        "The checklist is stored as `acm.yaml`. You can load it as a Python object or view the raw YAML."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "print(Path(\"acm.yaml\").read_text())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Export checklist\n",
+        "You can export the progress report to Markdown for sharing."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "!acm export --format markdown > checklist.md\n",
+        "!head checklist.md"
+      ]
+    }
+  ],
+  "metadata": {},
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/acm/__init__.py
+++ b/acm/__init__.py
@@ -1,5 +1,6 @@
 """Article Checklist Manager core package."""
 
 from .progress import TaskNode, progress_bar, render_tree
+from .colab import setup
 
-__all__ = ["TaskNode", "progress_bar", "render_tree"]
+__all__ = ["TaskNode", "progress_bar", "render_tree", "setup"]

--- a/acm/colab.py
+++ b/acm/colab.py
@@ -1,0 +1,64 @@
+"""Utilities for running Article Checklist Manager inside Google Colab."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _maybe_mount_drive() -> None:
+    """Mount Google Drive if running in Colab."""
+    try:
+        from google.colab import drive  # type: ignore
+
+        if not Path("/content/drive").exists():
+            drive.mount("/content/drive")
+    except Exception:
+        # Not running on Colab or drive already mounted
+        pass
+
+
+def setup(project: str = "DemoPaper", repo_url: str | None = None) -> Path:
+    """Prepare the Colab environment and return the project directory.
+
+    The helper performs a few convenience steps so new users can focus on
+    exploring the package:
+
+    1. Mount Google Drive (if available) so projects persist between sessions.
+    2. Clone the repository and install it in editable mode if ``repo_url`` is
+       provided and the repo is not already present.
+    3. Ensure a checklist project named ``project`` exists, creating it if
+       necessary.
+
+    Parameters
+    ----------
+    project:
+        Name of the checklist project directory to create.
+    repo_url:
+        Optional Git repository URL to clone. If ``None`` the current
+        directory is assumed to already contain the code.
+
+    Returns
+    -------
+    Path
+        Path to the project directory.
+    """
+
+    _maybe_mount_drive()
+
+    cwd = Path.cwd()
+    if repo_url:
+        repo_name = Path(repo_url).stem
+        if not (cwd / repo_name).exists():
+            subprocess.run(["git", "clone", repo_url], check=True)
+        cwd = cwd / repo_name
+
+    subprocess.run([sys.executable, "-m", "pip", "install", "-e", "."], cwd=cwd, check=True)
+
+    project_path = cwd / project
+    if not project_path.exists():
+        subprocess.run([sys.executable, "-m", "acm.cli", "init", project], cwd=cwd, check=True)
+    return project_path
+
+__all__ = ["setup"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,9 @@ dependencies = [
     "PyYAML>=6.0",
 ]
 
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["acm*"]
+
 [project.scripts]
 acm = "acm.cli:app"

--- a/tests/test_colab.py
+++ b/tests/test_colab.py
@@ -1,0 +1,11 @@
+from acm.colab import setup
+
+
+def test_setup_returns_path(tmp_path, monkeypatch):
+    def dummy_run(*args, **kwargs):
+        return 0
+    monkeypatch.setattr('subprocess.run', dummy_run)
+    monkeypatch.setattr('acm.colab._maybe_mount_drive', lambda: None)
+    path = setup(project="DemoPaper", repo_url=None)
+    assert path.name == "DemoPaper"
+


### PR DESCRIPTION
## Summary
- support editable installs by defining setuptools package discovery
- expose a new `acm.colab.setup` helper for use in notebooks
- update package `__init__` to export `setup`
- expand the Colab tutorial with a quick setup section and checklist inspection
- add basic unit test for the helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c95607b5c83219bf543bebee9f938