### PR TITLE
Implement drive stubs and update helpers

### DIFF
--- a/acm/cli.py
+++ b/acm/cli.py
@@ -23,7 +23,7 @@ def save_project(project: ArticleProject, path: Path = Path('.')) -> None:
 def ensure_task(project: ArticleProject, path: str) -> TaskNode:
     parts = [p for p in path.split('/') if p]
     tasks = project.checklist.tasks
-    node = None
+    node: TaskNode | None = None
     for part in parts:
         for t in tasks:
             if t.item == part:
@@ -33,13 +33,14 @@ def ensure_task(project: ArticleProject, path: str) -> TaskNode:
             node = TaskNode(item=part)
             tasks.append(node)
         tasks = node.subtasks
+    assert node is not None
     return node
 
 
 def find_task(project: ArticleProject, path: str) -> TaskNode:
     parts = [p for p in path.split('/') if p]
     tasks = project.checklist.tasks
-    node = None
+    node: TaskNode | None = None
     for part in parts:
         for t in tasks:
             if t.item == part:
@@ -48,6 +49,7 @@ def find_task(project: ArticleProject, path: str) -> TaskNode:
                 break
         else:
             raise typer.BadParameter(f"Task path not found: {'/'.join(parts)}")
+    assert node is not None
     return node
 
 

--- a/acm/domain.py
+++ b/acm/domain.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Any
+from typing import List, Optional, Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .progress import TaskNode as ProgressTaskNode
 import json
 import yaml
 
@@ -34,10 +37,8 @@ class TaskNode:
             return 0.0
         return sum(s.computed_percent() for s in self.subtasks) / len(self.subtasks)
 
-    def to_progress_node(self) -> 'ProgressTaskNode':
+    def to_progress_node(self) -> "ProgressTaskNode":
         """Convert to :class:`acm.progress.TaskNode` for rendering."""
-        from .progress import TaskNode as ProgressTaskNode
-
         pct = 100 if self.done else self.percent
         node = ProgressTaskNode(name=self.item, percent=pct)
         node.children = [s.to_progress_node() for s in self.subtasks]

--- a/acm/drive.py
+++ b/acm/drive.py
@@ -1,0 +1,19 @@
+"""Persistence helpers for saving and loading checklists from disk."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .domain import Checklist
+
+
+def save(project: Checklist, path: Path) -> None:
+    """Save ``project`` to ``path`` in YAML format."""
+    raise NotImplementedError
+
+
+def load(path: Path) -> Checklist:
+    """Return a :class:`Checklist` loaded from ``path``."""
+    raise NotImplementedError
+
+__all__ = ["save", "load"]

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,4 +1,3 @@
-import json
 from acm.domain import TaskNode, Checklist, ArticleProject
 
 

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from acm.domain import Checklist, TaskNode
+from acm import drive
+import pytest
+
+
+def test_save_and_load_roundtrip(tmp_path: Path) -> None:
+    pytest.skip("TODO: implement drive.save/load")
+    project = Checklist()
+    project.add_task(TaskNode(item="Task"))
+    file = tmp_path / "checklist.yaml"
+    drive.save(project, file)
+    restored = drive.load(file)
+    assert restored.to_dict() == project.to_dict()


### PR DESCRIPTION
## Summary
- stub out drive save/load helpers
- add placeholder tests for drive module
- tidy domain & CLI helper typing

## Testing
- `ruff check acm tests`
- `mypy . --ignore-missing-imports`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d29c72edc8321b9ad422dc09fae27