### PR TITLE
Integrate journal guideline database

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ An open-source tool that helps research teams track, from the top-level section 
 
 0.2 — Journal Templates
 	•	Built-in templates for Cell Press (STAR Methods), Nature, Science
+        •       Guidelines sourced from `journal_guidelines.json`
 	•	Automatic validation of mandatory checklist items
 
 0.3 — GUI (Electron / Tauri)

--- a/acm/__init__.py
+++ b/acm/__init__.py
@@ -2,5 +2,20 @@
 
 from .progress import TaskNode, progress_bar, render_tree
 from .colab import setup
+from .journal import (
+    Guideline,
+    load_guidelines,
+    find_guideline,
+    generate_template,
+)
 
-__all__ = ["TaskNode", "progress_bar", "render_tree", "setup"]
+__all__ = [
+    "TaskNode",
+    "progress_bar",
+    "render_tree",
+    "setup",
+    "Guideline",
+    "load_guidelines",
+    "find_guideline",
+    "generate_template",
+]

--- a/acm/cli.py
+++ b/acm/cli.py
@@ -132,5 +132,14 @@ def delete(task: str):
     typer.echo(f"Deleted {task}")
 
 
+@app.command()
+def template(journal: str, article_type: str = typer.Option(None)):
+    """Generate a journal checklist template."""
+    from .journal import generate_template
+
+    checklist = generate_template(journal, article_type)
+    typer.echo(checklist.to_yaml())
+
+
 if __name__ == "__main__":
     app()

--- a/acm/journal.py
+++ b/acm/journal.py
@@ -1,0 +1,70 @@
+"""Journal guideline utilities."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from .domain import Checklist, TaskNode
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDELINES_FILE = ROOT / "journal_guidelines.json"
+
+
+@dataclass
+class Guideline:
+    journal: str
+    article_type: str
+    title_limit: Optional[str] = None
+    abstract_limit: Optional[str] = None
+    word_limit: Optional[str] = None
+    figure_limit: Optional[str] = None
+    reference_limit: Optional[str] = None
+    structure: Optional[str] = None
+    other_requirements: Optional[str] = None
+    last_accessed: Optional[str] = None
+
+
+def load_guidelines(path: Path | None = None) -> List[Guideline]:
+    """Return all guidelines from ``journal_guidelines.json``."""
+    file = path or GUIDELINES_FILE
+    data = json.loads(file.read_text())
+    return [Guideline(**d) for d in data]
+
+
+def find_guideline(journal: str, article_type: str | None = None) -> Guideline:
+    """Return the guideline entry matching ``journal`` and ``article_type``."""
+    journal = journal.lower()
+    art = article_type.lower() if article_type else None
+    for g in load_guidelines():
+        if g.journal.lower() == journal and (art is None or g.article_type.lower() == art):
+            return g
+    raise ValueError(f"Guideline not found for {journal} {article_type or ''}")
+
+
+def generate_template(journal: str, article_type: str | None = None) -> Checklist:
+    """Generate a :class:`Checklist` based on guideline limits."""
+    g = find_guideline(journal, article_type)
+
+    tasks: List[TaskNode] = []
+    if g.title_limit:
+        tasks.append(TaskNode(item=f"Title limit: {g.title_limit}"))
+    if g.abstract_limit:
+        tasks.append(TaskNode(item=f"Abstract limit: {g.abstract_limit}"))
+    if g.word_limit:
+        tasks.append(TaskNode(item=f"Word limit: {g.word_limit}"))
+    if g.figure_limit:
+        tasks.append(TaskNode(item=f"Figure limit: {g.figure_limit}"))
+    if g.reference_limit:
+        tasks.append(TaskNode(item=f"Reference limit: {g.reference_limit}"))
+    if g.structure:
+        tasks.append(TaskNode(item=f"Structure: {g.structure}"))
+    if g.other_requirements:
+        tasks.append(TaskNode(item=f"Other requirements: {g.other_requirements}"))
+
+    return Checklist(tasks=tasks)
+
+
+__all__ = ["Guideline", "load_guidelines", "find_guideline", "generate_template"]

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,0 +1,12 @@
+from acm.journal import load_guidelines, generate_template
+
+
+def test_load_guidelines():
+    guidelines = load_guidelines()
+    assert len(guidelines) > 0
+
+
+def test_generate_template():
+    checklist = generate_template("Science (AAAS)")
+    assert checklist.tasks
+    assert any("Title limit" in t.item for t in checklist.tasks)


### PR DESCRIPTION
## Summary
- add `journal_guidelines.json` loader and template generator
- expose guideline helpers through `acm` package
- support `acm template` CLI command
- document JSON source in README
- test journal utilities

## Testing
- `pip install PyYAML`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68845cbb6e708321acd642313b65abfe