### PR TITLE
Add guideline utilities

### DIFF
--- a/FORMAT.md
+++ b/FORMAT.md
@@ -1,0 +1,18 @@
+# journal_guidelines.json Format
+
+An **array** of journal objects. Each object may contain:
+
+- `journal` (string): Journal name.
+- `article_type` or `article_types` (string or object/array): Types of articles.
+- `title_limit`, `abstract_limit`, `word_limit`, etc. (strings): Numeric limits.
+- `figure_limit` (string): Max figures/tables.
+- `reference_limit` (string): Max references.
+- `structure` (string): Required sections in the manuscript.
+- `other_requirements` (string or array): Additional notes or policies.
+- `mission_and_policies` (object): Nested policy fields (for JoCN).
+- `initial_submission`, `revised_submission`, etc. (object): Submission rules.
+- `manuscript_formatting`, `journal_cover_images`, etc. (object): Format specs.
+- `last_accessed` (string): ISO date when guidelines were fetched.
+
+Each top-level array element must be a valid JSON object; unknown fields are
+ignored by the loader.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ The YAML schema for the recursive `TaskNode` structure is defined in
 unlimited nesting via `subtasks`, includes a `done` flag for completion, and
 allows per-node progress overrides with the optional `percent` field.
 
+📚 Guideline Utilities
+
+        •       `append_guideline.py` – append a new guideline entry to `journal_guidelines.json`
+        •       `validate_json.py` – verify that `journal_guidelines.json` is valid JSON
+
+See [`FORMAT.md`](FORMAT.md) for the guideline schema.
+
 ⸻
 
 🤝 Contributing

--- a/append_guideline.py
+++ b/append_guideline.py
@@ -1,0 +1,31 @@
+import json
+
+
+def append_guideline(file_path: str, new_entry: dict) -> None:
+    """Append a guideline entry to ``file_path``.
+
+    Parameters
+    ----------
+    file_path:
+        Path to ``journal_guidelines.json``.
+    new_entry:
+        Guideline object to append.
+    """
+    with open(file_path, "r+", encoding="utf-8") as f:
+        data = json.load(f)
+        data.append(new_entry)
+        f.seek(0)
+        json.dump(data, f, indent=2)
+        f.truncate()
+
+
+def main() -> None:
+    file_path = "journal_guidelines.json"
+    new_entry: dict = {
+        # fill in your guideline fields here
+    }
+    append_guideline(file_path, new_entry)
+
+
+if __name__ == "__main__":
+    main()

--- a/validate_json.py
+++ b/validate_json.py
@@ -1,0 +1,24 @@
+import json
+import sys
+from pathlib import Path
+
+
+def validate_json(file_path: str) -> bool:
+    """Return ``True`` if ``file_path`` contains valid JSON."""
+    with open(file_path, "r", encoding="utf-8") as f:
+        try:
+            json.load(f)
+        except json.JSONDecodeError as e:
+            print(f"JSON validation error: {e}")
+            return False
+    print("JSON is valid.")
+    return True
+
+
+def main() -> None:
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("journal_guidelines.json")
+    validate_json(str(path))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `append_guideline.py` and `validate_json.py`
- describe JSON format in `FORMAT.md`
- document new scripts in the README

## Testing
- `ruff check .` *(fails: E402 in manuscript.py)*
- `mypy .` *(fails: missing type stubs)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884666ab98c8321b4727fd8057c21ea