### PR TITLE
Fix import error and enhance CLI functionality

### DIFF
--- a/acm/domain.py
+++ b/acm/domain.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Any, TYPE_CHECKING
+from typing import List, Optional, Any
 
-if TYPE_CHECKING:
-    from .progress import TaskNode as ProgressTaskNode
+from .progress import TaskNode as ProgressTaskNode
 import json
 import yaml
 


### PR DESCRIPTION
## Summary
- import `TaskNode` from progress module unconditionally to avoid `NameError`
- update `init` command to work in current directory and avoid overwriting
- improve `uncheck` with user-friendly error handling
- add confirmation prompt to `delete` command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688477fa90f88321ac026bb9c127e0ac